### PR TITLE
fix: When no host passed in, use default cloud endpoint

### DIFF
--- a/harlequin_wherobots/adapter.py
+++ b/harlequin_wherobots/adapter.py
@@ -29,6 +29,9 @@ if _log_file:
     )
 
 
+DEFAULT_CONNECTION = "api.cloud.wherobots.com"
+
+
 class HarlequinWherobotsCursor(HarlequinCursor):
     def __init__(self, cursor: Cursor) -> None:
         self.cursor = cursor
@@ -235,7 +238,7 @@ class HarlequinWherobotsAdapter(HarlequinAdapter):
             )
 
         # If no connection string is provided, let the driver use the default endpoint.
-        host = f"api.{self.conn_str[0]}" if self.conn_str else None
+        host = f"api.{self.conn_str[0]}" if self.conn_str else DEFAULT_CONNECTION
 
         try:
             return HarlequinWherobotsConnection(


### PR DESCRIPTION
Context:
https://wherobots.slack.com/archives/C04T19B6B6D/p1717474436518109

This didn't emerge in staging because we always specify the host

When we expect to run in prod and skip passing the host, the part that pull catalogs hierarchy will get `host=None` and the API calls will fail.
Create session wasn't affected because the dbapi-driver has the None value handled. 