### PR TITLE
fix: catalog-explorer API signature updated

### DIFF
--- a/harlequin_wherobots/adapter.py
+++ b/harlequin_wherobots/adapter.py
@@ -124,7 +124,7 @@ class HarlequinWherobotsConnection(HarlequinConnection):
     def get_catalog(self) -> Catalog:
         try:
             response = requests.get(
-                f"https://{self.host}/catalog/hierarchy",
+                f"https://{self.host}/catalogs/hierarchy",
                 headers=self.headers
             )
             response.raise_for_status()
@@ -194,7 +194,7 @@ class HarlequinWherobotsConnection(HarlequinConnection):
         """Get the schema for a table and add it to the table's CatalogItem."""
         logging.debug("Getting schema for %s.%s.%s ...", catalog, db, table)
         response = requests.get(
-            f"https://{self.host}/catalog/{catalog_id}/databases/{db}/tables/{table}",
+            f"https://{self.host}/catalogs/{catalog_id}/namespaces/{db}/tables/{table}",
             headers=self.headers,
         )
         if response.status_code != 200:


### PR DESCRIPTION
Task: [EWT-3722](https://www.notion.so/wherobots/Test-Harlequin-connector-with-catalogs-2aaba32ec02780bea966e58d9691074c?source=copy_link)

Purpose:
We changed wherobots's catalog explorer API signature, harlequin connector need to adept to the new API.